### PR TITLE
Fix usage of underscore in package version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,20 @@
 {% set name = "libopensubdiv" %}
 {% set version = "3_6_1" %}
-{% set version_tag = version.replace('.', "_") %}
+{% set version_conda = version.replace('_', ".") %}
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: {{ version_conda }}
 
 source:
-  - url: https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v{{ version_tag }}.tar.gz
+  - url: https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v{{ version }}.tar.gz
     sha256: e9d99a480d80e999667643747c76eb0138d36c418fc154fd71b4bd65be103d52
     patches:
       - disable_install_of_static_libraries.patch
       - enable_shared_library_on_windows.patch
 
 build:
-  number: 0
+  number: 1
   # SONAME is x.x.x
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x.x') }}


### PR DESCRIPTION
To be friendly with the autoupdated bot, we keep `version` to refer to how the tags are named (i.e. `3_6_1`, and instead the variable `version_conda` is used to contain the version actually used for the conda-package (i.e. 3.6.1).


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
